### PR TITLE
Fixes to setting up a project for development

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:14.16.0
 WORKDIR /app
 COPY package.json /app/package.json
+COPY yarn.lock /app/yarn.lock
 RUN yarn

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:14.16.0
 WORKDIR /app
 COPY package.json /app/package.json
+COPY yarn.lock /app/yarn.lock
 RUN yarn


### PR DESCRIPTION
Fixed:
- Now yarn.lock is copied to the containers to make sure that the versions of yarn packages are correct

TODO:
- There is some kind of a problem with starting the express server on a fresh setup of a project. Needs more investigation.